### PR TITLE
Don't connect Redis in during build

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -34,9 +34,14 @@ module.exports = function Cache (moduleOptions) {
     return
   }
 
-  const redis = new RedisCache(options)
+  let redis;
 
-  this.options.render.bundleRenderer.cache = redis
+  if (!process.argv.includes('build')) {
+
+    redis = new RedisCache(options)
+
+    this.options.render.bundleRenderer.cache = redis
+  }
 
   const plugins = [
     'components/index.js'


### PR DESCRIPTION
Prevent connection to Redis while building avoiding this message:

╭─────────────────────────────────────────────────────────────────────╮
   │                                                                     │
   │   ⚠ Nuxt Warning                                                    │
   │                                                                     │
   │   The command 'nuxt build' finished but did not exit after 5s       │
   │   This is most likely not caused by a bug in Nuxt                   │
   │   Make sure to cleanup all timers and listeners you or your         │
   │   plugins/modules start.                                            │
   │   Nuxt will now force exit                                          │
   │                                                                     │
   │   DeprecationWarning: Starting with Nuxt version 3 this will be a   │
   │   fatal error                                                       │
   │                                                                     │
   ╰─────────────────────────────────────────────────────────────────────╯